### PR TITLE
Correção dos erros apontados pelo Actions de vaga de emprego

### DIFF
--- a/.idea/Sistema-de-intermediacao-o-de-emprego.iml
+++ b/.idea/Sistema-de-intermediacao-o-de-emprego.iml
@@ -106,6 +106,11 @@
     <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.7.0, ruby-3.1.1-p18) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="reline (v0.3.2, ruby-3.1.1-p18) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, ruby-3.1.1-p18) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.12.0, ruby-3.1.1-p18) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.12.1, ruby-3.1.1-p18) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.12.2, ruby-3.1.1-p18) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.12.5, ruby-3.1.1-p18) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.12.0, ruby-3.1.1-p18) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.3.2, ruby-3.1.1-p18) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sassc (v2.4.0, ruby-3.1.1-p18) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sassc-rails (v2.1.2, ruby-3.1.1-p18) [gem]" level="application" />

--- a/db/migrate/20230316014640_create_entrevistadors.rb
+++ b/db/migrate/20230316014640_create_entrevistadors.rb
@@ -4,7 +4,7 @@ class CreateEntrevistadors < ActiveRecord::Migration[7.0]
       t.string :nome
       t.string :email
       t.string :telefone
-      t.references :vaga_de_emprego, null: false, foreign_key: true
+      t.references :vaga_de_emprego, null: false, foreign_key: {on_delete: :cascade}
 
       t.timestamps
     end

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -60,12 +60,12 @@ When('eu acesso uma vaga em especifico') do
   visit "/vaga_de_empregos/1"
 end
 
-And("eu clico no botao para deletar a vaga") do
+And('eu clico no botao para deletar a vaga') do
   expect(page).to have_content('Back to vaga de empregos')
   click_link_or_button 'Destroy this vaga de emprego'
 end
 
-Then("eu vejo a mensagem que diz que a vaga foi removida com sucesso") do
+Then('eu vejo a mensagem que diz que a vaga foi removida com sucesso') do
   expect(page).to have_content('Vaga de emprego foi destruida com sucesso.')
 end
 

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -70,7 +70,7 @@ end
 
 #Editar vaga
 And('eu acesso a pagina de edicao desta vaga') do
-  visit "/vaga_de_empregos/1/edit"
+  click_link_or_button 'Edit this vaga de emprego'
 end
 
 And('eu altero os campos desejados da vaga preenchendo a descricao com {string}') do |descricao|

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -57,7 +57,7 @@ And('eu estou na pagina de listagem de vagas') do
 end
 
 When('eu acesso uma vaga em especifico') do
-  click_link_or_button 'Show this vaga de emprego'
+  visit "/vaga_de_empregos/1"
 end
 
 And("eu clico no botao para deletar a vaga") do

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -58,7 +58,7 @@ end
 
 When('eu acesso uma vaga em especifico') do
   @vaga_de_emprego = VagaDeEmprego.first
-  visit "/vaga_de_empregos/1"
+  visit(vaga_de_emprego_path(@vaga_de_emprego))
 end
 
 And('eu clico no botao para deletar a vaga') do

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -57,7 +57,7 @@ And('eu estou na pagina de listagem de vagas') do
 end
 
 When('eu acesso uma vaga em especifico') do
-  visit "/vaga_de_empregos/1"
+  click_link_or_button 'Show this vaga de emprego'
 end
 
 And("eu clico no botao para deletar a vaga") do

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -57,6 +57,7 @@ And('eu estou na pagina de listagem de vagas') do
 end
 
 When('eu acesso uma vaga em especifico') do
+  @vaga_de_emprego = VagaDeEmprego.first
   visit "/vaga_de_empregos/1"
 end
 

--- a/features/step_definitions/vaga_steps.rb
+++ b/features/step_definitions/vaga_steps.rb
@@ -61,6 +61,7 @@ When('eu acesso uma vaga em especifico') do
 end
 
 And("eu clico no botao para deletar a vaga") do
+  expect(page).to have_content('Back to vaga de empregos')
   click_link_or_button 'Destroy this vaga de emprego'
 end
 


### PR DESCRIPTION
Foram corrigidos alguns erros de nomenclatura. Além disso, foi corrigido um erro chave estrangeira, pois a tabela "vaga_de_empregos" tem uma chave estrangeira (fk_rails_9fe85f71f0) que é referenciada pela tabela "entrevistadors". Isso significa que não é possível excluir um registro na tabela "vaga_de_empregos" enquanto houver um registro correspondente na tabela "entrevistadors". Em suma, coloquei para remover primeiro as referências à vaga de emprego da tabela "entrevistadors" antes de excluir a vaga de emprego com a opção de exclusão em cascata (on_delete: :cascade) na restrição de chave estrangeira.